### PR TITLE
small improvments to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-DEST ?= /usr/local/bin
+PREFIX ?= /usr/local
 
 all:
 	@echo Run \'make install\' to install mdt
 	@echo Run \'make uninstall\' to uninstall mdt
 
 install:
-	@install -Dm755 mdt $(DEST)/mdt
+	@install -Dm755 mdt $(DESTDIR)$(PREFIX)/bin/mdt
 	@echo mdt has been installed
 
 uninstall:
-	@rm -f $(DEST)/mdt
+	@rm -f $(DESTDIR)$(PREFIX)/bin/mdt
 	@echo mdt has been removed

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ all:
 	@echo Run \'make uninstall\' to uninstall mdt
 
 install:
-	@cp mdt $(DEST)/mdt
-	@chmod 755 $(DEST)/mdt
+	@install -Dm755 mdt $(DEST)/mdt
 	@echo mdt has been installed
 
 uninstall:


### PR DESCRIPTION
This improves the makefile to create its target directory (should it not exist already) and splits `$DEST` into the more commonly used `$DESTDIR` and `$PREFIX` variables.

https://www.gnu.org/prep/standards/html_node/DESTDIR.html
https://www.gnu.org/prep/standards/html_node/Directory-Variables.html

This would allow to make the `PKGBUILD` for `mdt` a little more clean:

```diff
@@ -12,6 +12,5 @@ sha256sums=('51c23b41452b007ae06b8f978d51fd618816762d0d6ecf670090448ffe61f2ac')

 package() {
   cd "$pkgname-$pkgver"
-  install -Dm755 $pkgname "$pkgdir"/usr/bin/$pkgname
-  make DEST="$pkgdir/usr/bin" install
+  make DESTDIR="$pkgdir" PREFIX="/usr" install
 }
```

Commits:
- makefile: use install to create the target directory
- makefile: convert DEST to DESTDIR and PREFIX
