### PR TITLE
fix: remove default item_width

### DIFF
--- a/mdt
+++ b/mdt
@@ -12,7 +12,6 @@ todo_filename="${MDT_NEW_FILE_NAMES}"
 color="${MDT_MAIN_COLOR:-5}"
 prompt="${MDT_PROMPT:-◆}"
 cursor="${MDT_CURSOR:-➔}"
-item_width="${MDT_ITEM_WIDTH:-75}"
 input_width="${MDT_INPUT_WIDTH:-65}"
 file_editor="${MDT_EDITOR:-${EDITOR}}"
 checkbox_prefix="${MDT_CHECKBOX_PREFIX:--}"
@@ -96,7 +95,7 @@ die() {
 }
 
 gum_choose() {
-  gum choose --item.width="${item_width}" \
+  gum choose ${item_width:+--item.width=${item_width}} \
     --selected.foreground="${color}" \
     --cursor.foreground="${color}" \
     --cursor="${cursor} " "$@"


### PR DESCRIPTION
I'm not sure if you'd be interested in this change.

I have noticed that non-selected items seem to be showing in a separate line from the prefix.

![image](https://github.com/user-attachments/assets/8e741c6b-66c7-498f-a09f-6ee8cdffb760)

This only seems to be the case for unselected items.

![image](https://github.com/user-attachments/assets/db32d818-458c-4549-a3e1-69ae42662004)

At first, this sounded like a terminal specific problem. But i have tried a bunch of terminal emulators (mainly foot and xfce4-terminal) and the problem seems to persist.

Note that the problem does not seem to depend on the value of item_width (I have tried values as big as 5000 and the problem still persisted).


I believe making item_width an option that is only passed to gum when set is a good solution for this problem. I am not sure if the problem used to exist with gum or not, and I think sending them a PR is a better fix than making a PR here (since it'd fix the problem at it's root). But I figured (since I'm already using this) that you might be interested in merging this until gum is fixed.